### PR TITLE
Add caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ Usage of go-callvis:
     	Enable verbose log.
   -file string
     	output filename - omit to use server mode
+  -cacheDir string
+    	Enable caching to avoid unnecessary re-rendering.
   -focus string
     	Focus specific package using name or import path. (default "main")
   -format string

--- a/analysis.go
+++ b/analysis.go
@@ -78,13 +78,14 @@ func mainPackages(pkgs []*ssa.Package) ([]*ssa.Package, error) {
 }
 
 type renderOpts struct {
-	focus   string
-	group   []string
-	ignore  []string
-	include []string
-	limit   []string
-	nointer bool
-	nostd   bool
+	cacheDir string
+	focus    string
+	group    []string
+	ignore   []string
+	include  []string
+	limit    []string
+	nointer  bool
+	nostd    bool
 }
 
 func (a *analysis) render(opts renderOpts) ([]byte, error) {

--- a/analysis.go
+++ b/analysis.go
@@ -88,7 +88,7 @@ type renderOpts struct {
 	nostd    bool
 }
 
-func (a *analysis) render(opts renderOpts) ([]byte, error) {
+func (a *analysis) render(opts *renderOpts) ([]byte, error) {
 	var (
 		err      error
 		ssaPkg   *ssa.Package

--- a/analysis.go
+++ b/analysis.go
@@ -85,6 +85,7 @@ type renderOpts struct {
 	include  []string
 	limit    []string
 	nointer  bool
+	refresh  bool
 	nostd    bool
 }
 

--- a/handler.go
+++ b/handler.go
@@ -141,6 +141,9 @@ func buildOptionsFromRequest(r *http.Request) *renderOpts {
 	if inter := r.FormValue("nointer"); inter != "" {
 		opts.nointer = true
 	}
+	if refresh := r.FormValue("refresh"); refresh != "" {
+		opts.refresh = true
+	}
 	if g := r.FormValue("group"); g != "" {
 		opts.group[0] = g
 	}
@@ -158,11 +161,15 @@ func buildOptionsFromRequest(r *http.Request) *renderOpts {
 }
 
 func findCachedImg(opts *renderOpts) string {
-	if opts.cacheDir == "" || opts.focus == "" {
+	if opts.cacheDir == "" || opts.refresh {
 		return ""
 	}
 
-	focusFilePath := opts.focus + "." + *outputFormat
+	focus := opts.focus
+	if focus == "" {
+		focus = "all"
+	}
+	focusFilePath := focus + "." + *outputFormat
 	absFilePath := filepath.Join(opts.cacheDir, focusFilePath)
 
 	if exists, err := pathExists(absFilePath); err != nil || !exists {
@@ -170,16 +177,20 @@ func findCachedImg(opts *renderOpts) string {
 		return ""
 	}
 
-	log.Println("hit cached img:", absFilePath)
+	log.Println("hit cached img")
 	return absFilePath
 }
 
 func cacheImg(opts *renderOpts, img string) error {
-	if opts.cacheDir == "" || opts.focus == "" || img == "" {
+	if opts.cacheDir == "" || img == "" {
 		return nil
 	}
 
-	absCacheDirPrefix := filepath.Join(opts.cacheDir, opts.focus)
+	focus := opts.focus
+	if focus == "" {
+		focus = "all"
+	}
+	absCacheDirPrefix := filepath.Join(opts.cacheDir, focus)
 	absCacheDirPath := strings.TrimRightFunc(absCacheDirPrefix, func(r rune) bool {
 		return r != '\\' && r != '/'
 	})

--- a/handler.go
+++ b/handler.go
@@ -181,7 +181,7 @@ func cacheImg(opts *renderOpts, img string) error {
 
 	absCacheDirPrefix := filepath.Join(opts.cacheDir, opts.focus)
 	absCacheDirPath := strings.TrimRightFunc(absCacheDirPrefix, func(r rune) bool {
-		return r != '\\'
+		return r != '\\' && r != '/'
 	})
 	err := os.MkdirAll(absCacheDirPath, os.ModePerm)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ var (
 	skipBrowser  = flag.Bool("skipbrowser", false, "Skip opening browser.")
 	outputFile   = flag.String("file", "", "output filename - omit to use server mode")
 	outputFormat = flag.String("format", "svg", "output file format [svg | png | jpg | ...]")
+	cacheDir     = flag.String("cacheDir", "", "Enable caching to avoid unnecessary re-rendering.")
 
 	debugFlag   = flag.Bool("debug", false, "Enable verbose log.")
 	versionFlag = flag.Bool("version", false, "Show version and exit.")

--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ var (
 	skipBrowser  = flag.Bool("skipbrowser", false, "Skip opening browser.")
 	outputFile   = flag.String("file", "", "output filename - omit to use server mode")
 	outputFormat = flag.String("format", "svg", "output file format [svg | png | jpg | ...]")
-	cacheDir     = flag.String("cacheDir", "", "Enable caching to avoid unnecessary re-rendering.")
+	cacheDir     = flag.String("cacheDir", "", "Enable caching to avoid unnecessary re-rendering, you can force rendering by adding 'refresh=true' to the URL query or emptying the cache directory")
 
 	debugFlag   = flag.Bool("debug", false, "Enable verbose log.")
 	versionFlag = flag.Bool("version", false, "Show version and exit.")

--- a/main.go
+++ b/main.go
@@ -64,7 +64,7 @@ func outputDot(fname string, outputFormat string) {
 		log.Fatalf("%v\n", e)
 	}
 
-	output, err := Analysis.render(opts)
+	output, err := Analysis.render(&opts)
 	if err != nil {
 		log.Fatalf("%v\n", err)
 	}


### PR DESCRIPTION
I found that when using the go-callvis for some large projects (such as kurbernetes), each package takes a long time to render, and these tasks cannot be reused. So i add caching function to avoid some unnecessary re-renderings.