### PR TITLE
Add rankdir command line flag for graph layout direction.

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ Usage of go-callvis:
     	Omit calls to unexported functions.
   -nostd
     	Omit calls to/from packages in standard library.
+  -rankdir
+        Direction of graph layout [LR | RL | TB | BT] (default "LR")
   -skipbrowser
     	Skip opening browser.
   -tags build tags

--- a/dot.go
+++ b/dot.go
@@ -17,6 +17,7 @@ import (
 var (
 	minlen  uint
 	nodesep float64
+	rankdir string
 )
 
 // location of dot executable for converting from .dot to .svg
@@ -102,7 +103,7 @@ const tmplGraph = `digraph gocallvis {
     labeljust="l";
     fontname="Arial";
     fontsize="14";
-    rankdir="LR";
+    rankdir="{{.Options.rankdir}}";
     bgcolor="lightgray";
     style="solid";
     penwidth="0.5";

--- a/main.go
+++ b/main.go
@@ -55,6 +55,7 @@ func init() {
 	// Graphviz options
 	flag.UintVar(&minlen, "minlen", 2, "Minimum edge length (for wider output).")
 	flag.Float64Var(&nodesep, "nodesep", 0.35, "Minimum space between two adjacent nodes in the same rank (for taller output).")
+	flag.StringVar(&rankdir, "rankdir", "LR", "Direction of graph layout [LR | RL | TB | BT]")
 }
 
 func logf(f string, a ...interface{}) {

--- a/output.go
+++ b/output.go
@@ -370,7 +370,6 @@ func printOutput(
 			attrs["color"] = "saddlebrown"
 		}
 
-
 		// use position in file where callee is called as tooltip for the edge
 		fileEdge := fmt.Sprintf(
 			"at %s:%d: calling [%s]",
@@ -418,7 +417,6 @@ func printOutput(
 		edges = append(edges, e)
 	}
 
-
 	logf("%d/%d edges", len(edges), count)
 
 	dot := &dotGraph{
@@ -430,6 +428,7 @@ func printOutput(
 		Options: map[string]string{
 			"minlen":  fmt.Sprint(minlen),
 			"nodesep": fmt.Sprint(nodesep),
+			"rankdir": fmt.Sprint(rankdir),
 		},
 	}
 


### PR DESCRIPTION
This PR adds the -rankdir flag to the command, enabling control of the graph layout direction 
eg from top to bottom instead of the default left to right.