### PR TITLE
Fix issue go-callvis with build tags

### DIFF
--- a/analysis.go
+++ b/analysis.go
@@ -77,11 +77,12 @@ func (a *analysis) DoAnalysis(
 	tests bool,
 	args []string,
 ) error {
+	buildFlagTags := getBuildFlagTags()
 	cfg := &packages.Config{
 		Mode:       packages.LoadAllSyntax,
 		Tests:      tests,
 		Dir:        dir,
-		BuildFlags: build.Default.BuildTags,
+		BuildFlags: getBuildFlags(),
 	}
 
 	initial, err := packages.Load(cfg, args...)
@@ -374,4 +375,21 @@ func copyFile(src, dst string) (int64, error) {
 	defer destination.Close()
 	nBytes, err := io.Copy(destination, source)
 	return nBytes, err
+}
+
+func getBuildFlags() []string {
+	buildFlagTags := getBuildFlagTags(build.Default.BuildTags)
+	if len(buildFlagTags) == 0 {
+		return nil
+	}
+
+	return []string{buildFlagTags}
+}
+
+func getBuildFlagTags(buildTags []string) string {
+	if len(buildTags) > 0 {
+		return "-tags=" + strings.Join(buildTags, ",")
+	}
+
+	return ""
 }

--- a/analysis.go
+++ b/analysis.go
@@ -77,7 +77,6 @@ func (a *analysis) DoAnalysis(
 	tests bool,
 	args []string,
 ) error {
-	buildFlagTags := getBuildFlagTags()
 	cfg := &packages.Config{
 		Mode:       packages.LoadAllSyntax,
 		Tests:      tests,


### PR DESCRIPTION
When call go-callvis with build tags like below, there is error occur because of miss-processing build tags before put It in build flags.
`go-callvis -tags=example ./main.go
` 
error content:
`exit status 1: stderr: cannot find package "example" in any of:
`
