### PR TITLE
docs: use 'go install' instead of 'go get'

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Here you can find descriptions for various types of output.
 ### Installation
 
 ```sh
-go get -u github.com/ofabry/go-callvis
+go install github.com/ofabry/go-callvis
 # or
 git clone https://github.com/ofabry/go-callvis.git
 cd go-callvis && make install

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Here you can find descriptions for various types of output.
 ### Installation
 
 ```sh
-go install github.com/ofabry/go-callvis
+go install github.com/ofabry/go-callvis@latest
 # or
 git clone https://github.com/ofabry/go-callvis.git
 cd go-callvis && make install


### PR DESCRIPTION
As of Go 1.17, 'go get' is deprecated, and as of 1.18 'go get' will no longer build packages. 'go install' should be used instead, see https://go.dev/doc/go-get-install-deprecation

Signed-off-by: mikaello <2505178+mikaello@users.noreply.github.com>